### PR TITLE
Set fixed width for corner cell in table editor

### DIFF
--- a/UmbHost.Tables.Client/src/table-property-editor.element.ts
+++ b/UmbHost.Tables.Client/src/table-property-editor.element.ts
@@ -1126,6 +1126,9 @@ private _toggleLinkClass() {
     .corner-cell {
         background: var(--uui-color-surface-alt, #f3f3f5);
         border: none;
+        width: 30px;
+        max-width: 30px;
+        min-width: 30px;
     }
 
     .row-drag-handle, .col-drag-handle { 


### PR DESCRIPTION
The left row with the drag & drop handles was of variable width and got real large if there were only a few columns:

<img width="1671" height="283" alt="image" src="https://github.com/user-attachments/assets/a8fa461d-d22d-44d1-81b2-bec9a05112f5" />

I can see the intention was to have it be 30px wide instead. Adding some styling to the corner cell fixed it so now it will look as expected: 

<img width="1113" height="775" alt="image" src="https://github.com/user-attachments/assets/08b14c52-875a-48e4-b5d7-40f03cc69c66" />
