### PR TITLE
added indexing code

### DIFF
--- a/UmbHost.Tables/Composers/UmbHostTablesComposer.cs
+++ b/UmbHost.Tables/Composers/UmbHostTablesComposer.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using UmbHost.Tables.PropertyEditors;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace UmbHost.Tables.Composers
+{
+    public class UmbHostTablesComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            builder.Services.AddSingleton<TablePropertyIndexValueFactory>();
+        }
+    }
+}

--- a/UmbHost.Tables/PropertyEditors/TablePropertyEditor.cs
+++ b/UmbHost.Tables/PropertyEditors/TablePropertyEditor.cs
@@ -11,21 +11,24 @@ namespace UmbHost.Tables.PropertyEditors;
 public class TablePropertyEditor : DataEditor
 {
     private readonly IIOHelper _ioHelper;
+    private readonly TablePropertyIndexValueFactory _propertyIndexValueFactory;
 
     public TablePropertyEditor(
         IDataValueEditorFactory dataValueEditorFactory,
-        IIOHelper ioHelper)
+        IIOHelper ioHelper,
+        TablePropertyIndexValueFactory propertyIndexValueFactory)
         : base(dataValueEditorFactory)
     {
         _ioHelper = ioHelper;
+        _propertyIndexValueFactory = propertyIndexValueFactory;
         SupportsReadOnly = true;
     }
 
     /// <inheritdoc />
-    protected override IConfigurationEditor CreateConfigurationEditor()
-    {
-        return new TableConfigurationEditor(_ioHelper);
-    }
+    protected override IConfigurationEditor CreateConfigurationEditor() => new TableConfigurationEditor(_ioHelper);
+
+    /// <inheritdoc />
+    public override IPropertyIndexValueFactory PropertyIndexValueFactory =>  _propertyIndexValueFactory;
 }
 
 /// <summary>

--- a/UmbHost.Tables/PropertyEditors/TablePropertyIndexValueFactory.cs
+++ b/UmbHost.Tables/PropertyEditors/TablePropertyIndexValueFactory.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using UmbHost.Tables.Models;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
+
+namespace UmbHost.Tables.PropertyEditors
+{
+    public class TablePropertyIndexValueFactory : IPropertyIndexValueFactory
+    {
+        private readonly ILogger<TablePropertyEditor> _logger;
+
+        public TablePropertyIndexValueFactory(ILogger<TablePropertyEditor> logger)
+        {
+            _logger = logger;
+        }
+
+        public IEnumerable<IndexValue> GetIndexValues(IProperty property, string? culture, string? segment, bool published, IEnumerable<string> availableCultures, IDictionary<Guid, IContentType> contentTypeDictionary)
+        {
+            var values = new List<object?>();
+
+            var rawValue = property.GetValue(culture, segment, published)?.ToString();
+
+            if (!string.IsNullOrWhiteSpace(rawValue))
+            {
+                try
+                {
+                    TableModel? table = JsonSerializer.Deserialize<TableModel>(rawValue);
+
+                    if (table?.HasContent == true)
+                    {
+                        values.AddRange(table.Rows
+                            .SelectMany(row => row.Cells)
+                            .Select(cell => cell.Value.StripHtml())
+                            .ToList()
+                        );
+                    }
+                }
+                catch (JsonException)
+                {
+                    _logger.LogError("Failed to parse table data for property '{PropertyAlias}'.", property.Alias);
+                }
+            }
+
+            yield return new IndexValue
+            {
+                Culture = culture,
+                FieldName = property.Alias,
+                Values = values
+            };
+        }
+    }
+}

--- a/UmbHost.Tables/PropertyEditors/TablePropertyIndexValueFactory.cs
+++ b/UmbHost.Tables/PropertyEditors/TablePropertyIndexValueFactory.cs
@@ -9,9 +9,9 @@ namespace UmbHost.Tables.PropertyEditors
 {
     public class TablePropertyIndexValueFactory : IPropertyIndexValueFactory
     {
-        private readonly ILogger<TablePropertyEditor> _logger;
+        private readonly ILogger<TablePropertyIndexValueFactory> _logger;
 
-        public TablePropertyIndexValueFactory(ILogger<TablePropertyEditor> logger)
+        public TablePropertyIndexValueFactory(ILogger<TablePropertyIndexValueFactory> logger)
         {
             _logger = logger;
         }


### PR DESCRIPTION
great package @nul800sebastiaan and so easy to migrate from limbo tables - thank you for putting the time and effort into build this 🫶 

we've ran into an issue where table content wasn't being indexed, meaning content pages weren't displaying in search results:

<img width="1179" height="642" alt="image" src="https://github.com/user-attachments/assets/9daad2ea-a836-4909-a47a-d49cc1b5b748" />
<img width="1164" height="198" alt="image" src="https://github.com/user-attachments/assets/3367d9f4-c4bb-4e74-86c1-8eea41f8ccbf" />

this pull requests adds a `IPropertyIndexValueFactory` implementation meaning content is indexed correctly:

<img width="1131" height="108" alt="image" src="https://github.com/user-attachments/assets/6b99a912-830e-4880-a155-2c3b4137712d" />

 