### PR TITLE
Fix BodyRows returning the header row in a single-row table

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ The main model representing the table:
 | `UseFirstColumnAsHeader` | `bool` | Whether the first column should render as `<th>` elements |
 | `RowCount` | `int` | Number of rows |
 | `ColumnCount` | `int` | Number of columns (from first row) |
+| `HasContent` | `bool` | Whether the table has at least one row containing a non-empty cell |
+| `IsEmpty` | `bool` | Inverse of `HasContent` |
+| `Cells` | `IReadOnlyList<IReadOnlyList<TableCell>>` | The rows projected to a two-dimensional list of cells |
+| `HeaderRow` | `TableRow?` | The first row when `UseFirstRowAsHeader` is `true`, otherwise `null` |
+| `BodyRows` | `IReadOnlyList<TableRow>` | The rows excluding the header row — see the note below |
+| `HeaderColumn` | `IReadOnlyList<TableCell>` | The first cell of every row when `UseFirstColumnAsHeader` is `true`, otherwise empty |
+
+> **Note on `BodyRows`:** the header row is only skipped when the table has more than one row. A single-row table with `UseFirstRowAsHeader` enabled returns that row from both `HeaderRow` and `BodyRows`, so rendering both would output it twice. The tag helper and `ToHtmlTable` are unaffected — they do not use `BodyRows`.
+
+Methods:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `GetCell(int rowIndex, int columnIndex)` | `TableCell?` | The cell at the given position, or `null` if either index is out of bounds |
+| `GetRow(int index)` | `TableRow?` | The row at the given index, or `null` if out of bounds |
+| `GetColumn(int columnIndex)` | `IReadOnlyList<TableCell>` | Every cell in the column, skipping rows that have too few cells |
 
 ### TableRow
 
@@ -210,6 +226,7 @@ Represents a single cell:
 | `RowSpan` | `int` | Row span. Reserved; cell spanning is not implemented, so this is always `1` |
 | `IsEmpty` | `bool` | Whether cell is empty |
 | `IsHeader` | `bool` | Whether cell is a header |
+| `IsSpanned` | `bool` | Whether the cell spans multiple rows or columns. Always `false` while spanning is unimplemented |
 
 ## Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -190,10 +190,8 @@ The main model representing the table:
 | `IsEmpty` | `bool` | Inverse of `HasContent` |
 | `Cells` | `IReadOnlyList<IReadOnlyList<TableCell>>` | The rows projected to a two-dimensional list of cells |
 | `HeaderRow` | `TableRow?` | The first row when `UseFirstRowAsHeader` is `true`, otherwise `null` |
-| `BodyRows` | `IReadOnlyList<TableRow>` | The rows excluding the header row — see the note below |
+| `BodyRows` | `IReadOnlyList<TableRow>` | The rows excluding the header row when `UseFirstRowAsHeader` is `true`, otherwise every row |
 | `HeaderColumn` | `IReadOnlyList<TableCell>` | The first cell of every row when `UseFirstColumnAsHeader` is `true`, otherwise empty |
-
-> **Note on `BodyRows`:** the header row is only skipped when the table has more than one row. A single-row table with `UseFirstRowAsHeader` enabled returns that row from both `HeaderRow` and `BodyRows`, so rendering both would output it twice. The tag helper and `ToHtmlTable` are unaffected — they do not use `BodyRows`.
 
 Methods:
 

--- a/UmbHost.Tables.Tests/TableModelTests.cs
+++ b/UmbHost.Tables.Tests/TableModelTests.cs
@@ -1,0 +1,55 @@
+using UmbHost.Tables.Models;
+
+namespace UmbHost.Tables.Tests;
+
+public class TableModelTests
+{
+    [Fact]
+    public void BodyRows_excludes_the_header_row()
+    {
+        var table = TestTable.Create([["h"], ["a"], ["b"]], firstRowHeader: true);
+
+        Assert.Equal(2, table.BodyRows.Count);
+        Assert.Equal("a", table.BodyRows[0].Cells[0].Value);
+        Assert.Equal("b", table.BodyRows[1].Cells[0].Value);
+    }
+
+    [Fact]
+    public void BodyRows_is_empty_when_the_only_row_is_the_header()
+    {
+        // Regression: the header row was only skipped when the table had more than one
+        // row, so a single-row table returned that row from both HeaderRow and BodyRows.
+        var table = TestTable.Create([["h"]], firstRowHeader: true);
+
+        Assert.Empty(table.BodyRows);
+    }
+
+    [Fact]
+    public void HeaderRow_and_BodyRows_never_contain_the_same_row()
+    {
+        foreach (var rowCount in new[] { 1, 2, 3 })
+        {
+            var values = Enumerable.Range(0, rowCount).Select(i => new[] { $"r{i}" }).ToArray();
+            var table = TestTable.Create(values, firstRowHeader: true);
+
+            Assert.NotNull(table.HeaderRow);
+            Assert.DoesNotContain(table.HeaderRow, table.BodyRows);
+        }
+    }
+
+    [Fact]
+    public void BodyRows_returns_every_row_when_the_first_row_is_not_a_header()
+    {
+        var table = TestTable.Create([["a"], ["b"]]);
+
+        Assert.Equal(2, table.BodyRows.Count);
+        Assert.Null(table.HeaderRow);
+    }
+
+    [Fact]
+    public void BodyRows_is_empty_for_a_table_with_no_rows()
+    {
+        Assert.Empty(new TableModel { UseFirstRowAsHeader = true }.BodyRows);
+        Assert.Empty(new TableModel().BodyRows);
+    }
+}

--- a/UmbHost.Tables/Models/TableModel.cs
+++ b/UmbHost.Tables/Models/TableModel.cs
@@ -66,9 +66,9 @@ public class TableModel
     /// Gets the body rows (excluding header row if UseFirstRowAsHeader is true).
     /// </summary>
     [JsonIgnore]
-    public IReadOnlyList<TableRow> BodyRows => 
-        UseFirstRowAsHeader && Rows.Count > 1 
-            ? Rows.Skip(1).ToList() 
+    public IReadOnlyList<TableRow> BodyRows =>
+        UseFirstRowAsHeader
+            ? Rows.Skip(1).ToList()
             : Rows.ToList();
 
     /// <summary>


### PR DESCRIPTION
Follow-up to #8, which merged before these two commits were pushed.

## The bug

```csharp
UseFirstRowAsHeader && Rows.Count > 1 ? Rows.Skip(1).ToList() : Rows.ToList()
```

`BodyRows` only skipped the header row when the table had **more than one row**. A single-row table with `UseFirstRowAsHeader` enabled returned that row from both `HeaderRow` and `BodyRows`, so anyone rendering both output it twice.

`Skip(1)` already handles empty and single-element sequences, so the count guard is removed rather than adjusted — it was the only source of the bug.

Found while documenting `BodyRows` for the README, not by reading the renderer.

## Behaviour change

This changes public API behaviour: `BodyRows` on a single-row header table now returns empty where it previously returned that row. The tag helper and `ToHtmlTable` are unaffected — neither uses `BodyRows`.

## Tests

5 new tests in `TableModelTests.cs`, including `HeaderRow_and_BodyRows_never_contain_the_same_row`, which asserts the invariant across 1, 2 and 3 row tables rather than just patching the single-row case. Two of the five failed before the fix and pass after; 41 tests pass overall.

## README

Also documents the remaining public model members, which were all public but undocumented: `TableModel`'s `HasContent`, `IsEmpty`, `Cells`, `HeaderRow`, `BodyRows` and `HeaderColumn`, its `GetCell`/`GetRow`/`GetColumn` methods, and `TableCell.IsSpanned`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
