### PR TITLE
Bump version to 17.3.0

### DIFF
--- a/UmbHost.Tables.Client/package-lock.json
+++ b/UmbHost.Tables.Client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "umbhost-tables-client",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "umbhost-tables-client",
-      "version": "17.2.0",
+      "version": "17.3.0",
       "devDependencies": {
         "@umbraco-cms/backoffice": "^17.3.5",
         "lit": "^3.2.0",

--- a/UmbHost.Tables.Client/package.json
+++ b/UmbHost.Tables.Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbhost-tables-client",
-  "version": "17.2.0",
+  "version": "17.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/UmbHost.Tables/UmbHost.Tables.csproj
+++ b/UmbHost.Tables/UmbHost.Tables.csproj
@@ -9,7 +9,7 @@
     <!-- Package Info -->
     <PackageId>UmbHost.Tables</PackageId>
     <!-- Fallback for untagged builds; the Release workflow overrides this from the git tag. -->
-    <Version>17.2.0</Version>
+    <Version>17.3.0</Version>
     <Authors>UmbHost</Authors>
     <Company>UmbHost</Company>
     <Description>A table property editor for Umbraco 17 that allows content editors to create and manage tabular data with support for header rows/columns and rich text editing.</Description>


### PR DESCRIPTION
`17.2.0` is already published to NuGet (alongside 17.0.0, 17.0.1, 17.0.2 and 17.1.0), so the csproj fallback would stamp CI artifacts off `main` with a version that's already taken.

## Why 17.3.0 and not 17.2.1

The changes since 17.2.0 are breaking:

1. **`TablePropertyValueConverter`'s public constructor** now takes `HtmlLocalLinkParser`, `HtmlUrlParser` and `HtmlImageSourceParser`. It previously had the implicit parameterless constructor, so anyone subclassing it or constructing it directly no longer compiles. Umbraco's DI resolves it by type and is unaffected.
2. **`BodyRows`** on a single-row header table now returns empty where it previously returned that row.

Softer, but worth knowing: cell values now contain resolved URLs rather than `{localLink:…}` tokens, so any consumer workaround that string-replaced the token is relying on behaviour that's gone.

Semver would call the constructor change a major, but the major tracks the Umbraco major, so a minor is the strongest signal available here.

Also bumps `Client/package.json` to match — aligning it was the point of the earlier change, and leaving it behind would restart the drift.

Verified: `dotnet pack` produces `UmbHost.Tables.17.3.0.nupkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
