### PR TITLE
Move main to the Umbraco 18 line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - main       # Umbraco 18 line
+      - v17/main   # Umbraco 17 maintenance line
   pull_request:
     branches:
       - main
+      - v17/main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UmbHost.Tables
 
-A table property editor for Umbraco 17+ that allows content editors to create and manage tabular data with support for header rows, header columns, and inline editing.
+A table property editor for Umbraco 17 and 18 that allows content editors to create and manage tabular data with support for header rows, header columns, and inline editing.
 
 ## Features
 
@@ -12,6 +12,17 @@ A table property editor for Umbraco 17+ that allows content editors to create an
 - Configurable min/max rows and columns
 - Read-only mode support
 - Built with Lit/Vite/TypeScript following Umbraco 17 patterns
+
+## Version compatibility
+
+The package major tracks the Umbraco major, so pick the line that matches your site:
+
+| Umbraco | UmbHost.Tables | Branch |
+|---------|----------------|--------|
+| 18.x    | 18.x           | `main` |
+| 17.x    | 17.x           | `v17/main` |
+
+Both lines are built from the same source; the 17 line receives fixes by cherry-pick.
 
 ## Installation
 
@@ -25,6 +36,12 @@ Or via the Package Manager Console:
 
 ```powershell
 Install-Package UmbHost.Tables
+```
+
+NuGet resolves the newest version compatible with your Umbraco install. To pin a line explicitly:
+
+```bash
+dotnet add package UmbHost.Tables --version 17.*
 ```
 
 ## Usage

--- a/UmbHost.Tables.Client/package-lock.json
+++ b/UmbHost.Tables.Client/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "umbhost-tables-client",
-  "version": "17.3.0",
+  "version": "18.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "umbhost-tables-client",
-      "version": "17.3.0",
+      "version": "18.0.0",
       "devDependencies": {
-        "@umbraco-cms/backoffice": "^17.3.5",
+        "@umbraco-cms/backoffice": "^18.0.2",
         "lit": "^3.2.0",
         "typescript": "~5.6.3",
         "vite": "^6.4.2"
@@ -1565,1131 +1565,56 @@
       "license": "MIT"
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "17.3.5",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.5.tgz",
-      "integrity": "sha512-8GDjy8if4wFHLT68UWVma1FzDnEGuQtWbg+v2GRLhSpA8FSKJIXgj6d1Hg78enT9cOyN5T6UaiRa9SmNANsTXA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-18.0.2.tgz",
+      "integrity": "sha512-Dj49Y7VbT3v/BSRG/vL0AawyhUVQIYc15CBwxFLLeH9INwvZxa3rMnjrCovI7aZe7RyHpBHrY1dbXx6eIp+8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=22.17.1",
-        "npm": ">=10.9.2"
+        "node": ">=24.13",
+        "npm": ">=11"
       },
       "peerDependencies": {
         "@heximal/expressions": ">=0.1.5 <1.0.0",
-        "@hey-api/openapi-ts": ">=0.85.0 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.97.0 <1.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@tiptap/core": "^3.16.0",
-        "@tiptap/extension-image": "^3.16.0",
-        "@tiptap/extension-subscript": "^3.16.0",
-        "@tiptap/extension-superscript": "^3.16.0",
-        "@tiptap/extension-table": "^3.16.0",
-        "@tiptap/extension-text-align": "^3.16.0",
-        "@tiptap/extension-text-style": "^3.16.0",
-        "@tiptap/extensions": "^3.16.0",
-        "@tiptap/pm": "^3.16.0",
-        "@tiptap/starter-kit": "^3.16.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
         "@types/diff": "^7.0.2",
-        "@umbraco-ui/uui": "^1.17.2",
-        "@umbraco-ui/uui-css": "^1.17.1",
-        "diff": "^8.0.3",
-        "dompurify": "^3.3.0",
+        "@umbraco-ui/uui": "^2.0.0",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.1",
         "element-internals-polyfill": "^3.0.2",
         "lit": "^3.3.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.1",
+        "marked": "^18.0.0",
         "monaco-editor": ">=0.55.1 <1.0.0",
         "rxjs": "^7.8.2",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.3.tgz",
-      "integrity": "sha512-cMXJlqXexfZvasAiWKLbVkUnZ5PA/fRH/0SGtnp3aiSAdTZqCqNg9qjygX9GPN9PczJlRyBB/Y1mp50p27cQqw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-2.0.2.tgz",
+      "integrity": "sha512-OcRJ+l6mr9Yp4y0hCg0Tp38ib+qzednOaZ4yRmx+2YZ4vQ8A5DYpAXFMK1mzorSBlkF6iEIg1DwUl12ieoQBXw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.3",
-        "@umbraco-ui/uui-avatar": "1.17.3",
-        "@umbraco-ui/uui-avatar-group": "1.17.3",
-        "@umbraco-ui/uui-badge": "1.17.3",
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-boolean-input": "1.17.3",
-        "@umbraco-ui/uui-box": "1.17.3",
-        "@umbraco-ui/uui-breadcrumbs": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-button-copy-text": "1.17.3",
-        "@umbraco-ui/uui-button-group": "1.17.3",
-        "@umbraco-ui/uui-button-inline-create": "1.17.3",
-        "@umbraco-ui/uui-card": "1.17.3",
-        "@umbraco-ui/uui-card-block-type": "1.17.3",
-        "@umbraco-ui/uui-card-content-node": "1.17.3",
-        "@umbraco-ui/uui-card-media": "1.17.3",
-        "@umbraco-ui/uui-card-user": "1.17.3",
-        "@umbraco-ui/uui-caret": "1.17.3",
-        "@umbraco-ui/uui-checkbox": "1.17.3",
-        "@umbraco-ui/uui-color-area": "1.17.3",
-        "@umbraco-ui/uui-color-picker": "1.17.3",
-        "@umbraco-ui/uui-color-slider": "1.17.3",
-        "@umbraco-ui/uui-color-swatch": "1.17.3",
-        "@umbraco-ui/uui-color-swatches": "1.17.3",
-        "@umbraco-ui/uui-combobox": "1.17.3",
-        "@umbraco-ui/uui-combobox-list": "1.17.3",
-        "@umbraco-ui/uui-css": "1.17.3",
-        "@umbraco-ui/uui-dialog": "1.17.3",
-        "@umbraco-ui/uui-dialog-layout": "1.17.3",
-        "@umbraco-ui/uui-file-dropzone": "1.17.3",
-        "@umbraco-ui/uui-file-preview": "1.17.3",
-        "@umbraco-ui/uui-form": "1.17.3",
-        "@umbraco-ui/uui-form-layout-item": "1.17.3",
-        "@umbraco-ui/uui-form-validation-message": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-icon-registry": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
-        "@umbraco-ui/uui-input": "1.17.3",
-        "@umbraco-ui/uui-input-file": "1.17.3",
-        "@umbraco-ui/uui-input-lock": "1.17.3",
-        "@umbraco-ui/uui-input-password": "1.17.3",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.17.3",
-        "@umbraco-ui/uui-label": "1.17.3",
-        "@umbraco-ui/uui-loader": "1.17.3",
-        "@umbraco-ui/uui-loader-bar": "1.17.3",
-        "@umbraco-ui/uui-loader-circle": "1.17.3",
-        "@umbraco-ui/uui-menu-item": "1.17.3",
-        "@umbraco-ui/uui-modal": "1.17.3",
-        "@umbraco-ui/uui-pagination": "1.17.3",
-        "@umbraco-ui/uui-popover": "1.17.3",
-        "@umbraco-ui/uui-popover-container": "1.17.3",
-        "@umbraco-ui/uui-progress-bar": "1.17.3",
-        "@umbraco-ui/uui-radio": "1.17.3",
-        "@umbraco-ui/uui-range-slider": "1.17.3",
-        "@umbraco-ui/uui-ref": "1.17.3",
-        "@umbraco-ui/uui-ref-list": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3",
-        "@umbraco-ui/uui-ref-node-data-type": "1.17.3",
-        "@umbraco-ui/uui-ref-node-document-type": "1.17.3",
-        "@umbraco-ui/uui-ref-node-form": "1.17.3",
-        "@umbraco-ui/uui-ref-node-member": "1.17.3",
-        "@umbraco-ui/uui-ref-node-package": "1.17.3",
-        "@umbraco-ui/uui-ref-node-user": "1.17.3",
-        "@umbraco-ui/uui-scroll-container": "1.17.3",
-        "@umbraco-ui/uui-select": "1.17.3",
-        "@umbraco-ui/uui-slider": "1.17.3",
-        "@umbraco-ui/uui-symbol-expand": "1.17.3",
-        "@umbraco-ui/uui-symbol-file": "1.17.3",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.3",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.3",
-        "@umbraco-ui/uui-symbol-folder": "1.17.3",
-        "@umbraco-ui/uui-symbol-lock": "1.17.3",
-        "@umbraco-ui/uui-symbol-more": "1.17.3",
-        "@umbraco-ui/uui-symbol-sort": "1.17.3",
-        "@umbraco-ui/uui-table": "1.17.3",
-        "@umbraco-ui/uui-tabs": "1.17.3",
-        "@umbraco-ui/uui-tag": "1.17.3",
-        "@umbraco-ui/uui-textarea": "1.17.3",
-        "@umbraco-ui/uui-toast-notification": "1.17.3",
-        "@umbraco-ui/uui-toast-notification-container": "1.17.3",
-        "@umbraco-ui/uui-toast-notification-layout": "1.17.3",
-        "@umbraco-ui/uui-toggle": "1.17.3",
-        "@umbraco-ui/uui-visually-hidden": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.3.tgz",
-      "integrity": "sha512-d4B/SvhSEEOooYffEfKbfNBATviFKQ21OM+CApz5GGE49jHqpl4jVoVfum2YWiqQexNtRNQEckGCHUg2OZlLJg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button-group": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.3.tgz",
-      "integrity": "sha512-peTFJuk/c10NAD7oP2k8PkvdYzmBNVvrHmmhAOs0LBdrgRMCqstLqDABi17XH0MHYZEf1n8Z/DjnTCOBw9Tchw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.3.tgz",
-      "integrity": "sha512-+6kslm21rzqXVYMd1l07gW3k00+YGAufEOSQMxn5HAUnqq9dZu0X70LInx+pOZhEBsBakbv/zgAU9Wa36Rl38Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.3",
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.3.tgz",
-      "integrity": "sha512-Y9TcBSDHpcgq1zOf54KmXCnIKst6tG4KVKGAIcPllwFnkfmmaS+AFIWojXAM/1REF9BMsqw4tuSFiGg8HbwmsQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.3.tgz",
-      "integrity": "sha512-K8UtW39qE4rqfaZF5/oxi58cdaweCXPbda+Yl1MyPjJjesxpvh1TOXbsmol1WzOq/S2Atnr+uOMp5Ogc+p0VBg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "lit": ">=2.8.0"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.3.tgz",
-      "integrity": "sha512-D798gTVjokjcFqL4dnYVW431mRp5xjxsY8cCgc4lBW/xpS1T56+rF0jZdCBamrraCEkGB5KXF1wPuJsK+knIsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.3.tgz",
-      "integrity": "sha512-dJ0Nl4ao08MiEwsjcixIbxSvB/O+/52nnK8EQ+tNBQbCFb5sAzhGIySlDmLe8rLHUhvjgHzVXDIWWOtKd4myYw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-css": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.3.tgz",
-      "integrity": "sha512-9DtncHwG+gy4eIGV2kAiA6Nhcpf7rsIvtME8ECBpwgVd1j46dByNFuNJidHEIMJ+i4yAwIRplkw/ybKI55ZPOg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-responsive-container": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.3.tgz",
-      "integrity": "sha512-DbjPjZ+iOMucFJ4nok8+pyL9REXx256tNU8ELaZ7B0daOaTA9WF/dxbtj2GPbR9P1unIv5hlzm3gP4sfFD0n6w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-copy-text": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.3.tgz",
-      "integrity": "sha512-jeP8QHctw3U2InbyPxaXIJ7Ty9raYGDCMaVdcwlAu/ZM+y7tgQKxKSAAKSc3cgAKBK7Bzmvlpl34qTYlrXiztQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.3.tgz",
-      "integrity": "sha512-kEHEknYycvekd0U8fSldbBbPNIqSPmhj1pdCnZgW3QPrIot0Jl2biI50+d3lSll9/Lf19Y5m7txysunp3t+Snw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.3.tgz",
-      "integrity": "sha512-Z1RwWVfpcBcvBVNi82xN7VG/9+ZDmZA9N8ysTB9bNeb96WCumGgfRy1Nf8QRtxIS6mcZmxLd5ozdc8Ae4LL9tA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.3.tgz",
-      "integrity": "sha512-LLJaEv20KGNaE6AB+zmYUbJXq6D4PuYnBjErK6QsBWbN/bihU83SQgV/pv3vbQYYH3zLE+5iQl4NY9XK1BE49g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-checkbox": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.3.tgz",
-      "integrity": "sha512-WF/SJ1BrxnAajaU+py4ddZ/rf1mT3tddfx75kPXiA3880rDHOwWTznYWVXeMBNZrZeR34hQGe6L+RLjirDG2MQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-card": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.3.tgz",
-      "integrity": "sha512-YkUMfc4GExzRC1RJKICc4Py0SLCxMHDwfnkJCeyu/PBHD70uqcykkNFTQB76oG5MQwf5xHqaGBju2o2p+LPOmA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-card": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.3.tgz",
-      "integrity": "sha512-5pf6Ehh/Lex3rGnUHfHcxZfSqUwZ8G98zFMuGTmXSFax63w0moM+pAlt7Fv3ZpADgWzwFL+n+R+f09S78oz3Rw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-card": "1.17.3",
-        "@umbraco-ui/uui-symbol-file": "1.17.3",
-        "@umbraco-ui/uui-symbol-folder": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.3.tgz",
-      "integrity": "sha512-b6vYP1TjTGltG9XIsiU3GndnetT4pzteqNTNniFp3dnqOG2Q90ERHm5Zuyo+j6hKhpunGzQX1Uud3ZHtvxPF0g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.17.3",
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-card": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.3.tgz",
-      "integrity": "sha512-zCHdmiaDNgUG0jEyzK5dEYrqE85pIXl/NzPBJJdcYdKlrF6sIvdR/lJhZ5t8fMaWN6/91kqL4sdILy81733rQg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.3.tgz",
-      "integrity": "sha512-Bk70t/9+4492arU3tvhXJpwxgnAPfPgC/cP5bNcM2PbgYKhhqSNSj7ar0Kx3WCazb3IwDicqC13AYxFxNmr/lQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-boolean-input": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.3.tgz",
-      "integrity": "sha512-Ba1CO1hBetldzPkLOF+7ZWCnt1P2Ima07GSzeCChIKCLDZZl+Pwejp4v6ZubxtiQhgBXAFewzoaEyigpAz0i1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.3.tgz",
-      "integrity": "sha512-VBm8lUESSwmTURl6AP1tUobEitkhxAc8Hv01bkrEhGozh32UqtcakKAhqPyGKwxWZoNeamL9/w2zaMH7OUafSA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-popover-container": "1.17.3",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.3.tgz",
-      "integrity": "sha512-Kbfz+LLM0O2lZDTZcZ5d4RJQalOLjKXIjH+NIUrzkMKIOQpaUOGosPJw2yzk9dryxraWD9NKm2+qVybRkZJkLQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.3.tgz",
-      "integrity": "sha512-RunDonsYl7JBFOSS3hvr0HPCE2+c407+Tm1rd0X6S04I5m6JPvdeozwWT6tVIa42cAtRcAno5QnilSTDj9i8kw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
-        "colord": "^2.9.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.3.tgz",
-      "integrity": "sha512-2XSzT51adGe7KN4cl9K0Moq3eXbL8lfhl1rXwWR4kbR/8hs61yLQxqr+/YfgTF2tJz5sHvl6IKkkd+WP50zWfA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-color-swatch": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.3.tgz",
-      "integrity": "sha512-JVqxnzh9ROvCuvSwKP69p26SmHg30L7srqkBj4lXSMVXatVQ7bAGsTTe/QRfjnsE7NJM82/9upMaKrb46keU5g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-combobox-list": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-popover-container": "1.17.3",
-        "@umbraco-ui/uui-scroll-container": "1.17.3",
-        "@umbraco-ui/uui-symbol-expand": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.3.tgz",
-      "integrity": "sha512-qWNtKOiWsPbNlUS+/P2E/YpNg5GLUwIG3pIdqDxbhAPOxg3VmX0CT520Spd6aIicPAtX9YaTNbmyg2M3G+xlqA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.3.tgz",
-      "integrity": "sha512-LjmawpW91rWGnXSGmmZOusw7+6CP2AgLD8iep5Cp9bOzFWDXJXzEIyRtH7Aj27mD82kJDeGgQ+Wwf9XRIGnejw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "lit": ">=2.8.0"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.3.tgz",
-      "integrity": "sha512-kN/BRrXcAsLzLJZLTvVayPs5U8iXMNSW9RcUZwIGj+3qAi3EdVy2yr+KTjWRlRQc9MjmSXrda976uhHiQ7yY+g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-css": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.3.tgz",
-      "integrity": "sha512-BuvuSXGdo6MMnn65cOa6EvLzzZ//NHi2bcgIVtJ9JpikcTuIbWMSSiJ1KUA4fHJ2GrYtE4G30pB9iyQmUkWc7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.3.tgz",
-      "integrity": "sha512-NBXDioz4UGJLyQwWfpjeKkg14yvZ+mPI0fASDPKJX0I6lWu+6uv/nRLMKniARld2f8HYrdD90zYe/fd4rlN8tw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.3.tgz",
-      "integrity": "sha512-JzW27JBmAVbrbS6OHAeouJ8J0IL3RneWuPiS/T8deyMfWtCxqGd/IJlaSpg77enhAoaGjJRmHpXTSQEU/lO5xw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-symbol-file": "1.17.3",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.3",
-        "@umbraco-ui/uui-symbol-folder": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.3.tgz",
-      "integrity": "sha512-3Gl0t8LDv5co8C3sTkfkJQj5oGYbvBG/gJNnz2+Wv7s79fhUoCnxzHujU/dFKP8NyaIilAST+4RfHZ4bj1UAGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.3.tgz",
-      "integrity": "sha512-qC8f80z/NsfGrcDXucqdd4fsix8i5mRJzYuZLvKJX2pfQGg1SfKIL1nRq5kkre7qrPRzSAJKzP11jkuOgpgC9g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-form-validation-message": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.3.tgz",
-      "integrity": "sha512-frkIM6gKm2SeV/2MYUdw7RgWLCzsYIND7dgKL9Pt7x9bYsOjRHCwx1Ti3fg1E4OBGSURF46grRrIQmajaxKm6w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.3.tgz",
-      "integrity": "sha512-gYJeTqEYZTod8i2LvBLtcRu65S+2QMagfEGY4F+vsyVmBDfMpRAfrbZuw8OapYA3vBRYiXxHUMDQHfqFj4ccNg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.3.tgz",
-      "integrity": "sha512-As6BTo45VcXrULfmEeqdHYrN3VVpx7VkxHqPV9EY49bxWLQZPjI+dkgX8tDFeRoARktFDy5JFcXnS9L+ViZGXA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.3.tgz",
-      "integrity": "sha512-abJx8uR/BhpMYmAUUnIWYuYAgG/G7vHCKX+LOkO894qy6knspuaxbhimp0o490lMEOSTxHXnA2VakcGcuXXbpA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon-registry": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.3.tgz",
-      "integrity": "sha512-8H65YH6ZsiGbmME7IubcnVdq3WzEGoyZu0Kj568sm1r531ht376XYeasMjewTy5k5rWvc9PQZZDsm6suoWHSeg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.3.tgz",
-      "integrity": "sha512-IrHeQ1btodgHAV/gjhgZwbocertS7nelP6mdV36nfpQJulFJLV81uCW8BE2jOvGDvwy9dpm4ySLYnOS74CFOoQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.17.3",
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-file-dropzone": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.3.tgz",
-      "integrity": "sha512-XA1UsSlEzRxXh/8kbiLFH8p+72gfcXR0aKPlH7wvMqM3zMi9iluPQIMO9LfZQFL1Na6CNFzZxZbB37X9eEnENg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-input": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.3.tgz",
-      "integrity": "sha512-GNYxNe7HkVF4T/iDeHTMlueTiT/UX4d0wyC7qgA+YOw8bojx2zBEMKaVwaJUkjl65ipdkV9Lub2gsoZp8iw9og==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
-        "@umbraco-ui/uui-input": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.3.tgz",
-      "integrity": "sha512-QFQnAPPWzIE2mePXqHrct50pmAw8FLj4juYmtjXoWMtNGlphxNIZM7wiiuqiHsyThYKCuLLWXNH42ucAw6CEVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.3.tgz",
-      "integrity": "sha512-cLiikdhIVyK/roU0S0NPg+yUqYegnjprOyosNXez46kHdsZTbN45+du3cn9ir3NQmrWJs4njyQeosB+jSSSp1g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.3.tgz",
-      "integrity": "sha512-mUfJ8FqxqVg2Csg0D5Bni7OkDxVNGwGhrG9xb+8PDUZQToqK/ojvLju2EX/9acD7ogIT99L4K68AVJ0+I3XvIw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.3.tgz",
-      "integrity": "sha512-rj4sCiKO5glx/uhNn8KxCvM+8dumudUGy4tOMTpdAzbxVpytuLcf4RQSIF32j2CMWNDDS64eoOb1KAZr0Ry8xA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.3.tgz",
-      "integrity": "sha512-dcCeVtmtrssUDo8z41lx68F25Io7mVQgFShhzFgMKUzVWY5LuoRdHEjNPkXHt6DaNOkik+ONr1l9ZeScjPENAw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.3.tgz",
-      "integrity": "sha512-mwA6gPHhPtalvE+RWNOppwxRJa1tLgG+Z117SA/8RIri5HRpEGXcnZ1D1SJXkN3xGC0EnirTgCFsRwpUuF7iaA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-loader-bar": "1.17.3",
-        "@umbraco-ui/uui-symbol-expand": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.3.tgz",
-      "integrity": "sha512-OPJzQj4gsd7BZK+O2Kp/XXwwUP8h9lsIa7gvtNrrn6VGl7vRDpud6b0NlhjT7rJ5EgpCLYnLxX87TbdAwio7Tg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.3.tgz",
-      "integrity": "sha512-zbAQAiWnQ7CyCtD+ashaI9QUga1N/s6Dg9U8ZdzzknE5pljx957EdBVpcEgXRmTB4UW5DyDYDhPEo5A7+DKQ3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-button-group": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.3.tgz",
-      "integrity": "sha512-/TsDXLVqhKuypSycGhhdkraASjp8oC25oVnFYF8Up1KgWZ3FptishMuNV8ppSisKX0NoF01z1OU0ZTlW3EH0jw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.3.tgz",
-      "integrity": "sha512-+9VzTi4n9ke3OIEJDb1W5IAIyYUJHl65zBRruRorSpnDCtcYXoYiuxmI0C+CnYQ+TVS1MxxTSrfMTzs/j/y3KQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.3.tgz",
-      "integrity": "sha512-tJ5dcVS56T9Vyp4denVDF2VL5nhzlkSvr+a4eLruhCVHsi2Nlbf1QIx8WgVS8xSDQ4DN3YsSnaeBSEJYPbfLeA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.3.tgz",
-      "integrity": "sha512-kMorQngogGk3wVgBgHrmlSbX3saY3NNsHzikhQOzYct+TJjLfJ6PeomaPyUvD0yxb0tzUTbNYPhaM2XoU7hmoQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.3.tgz",
-      "integrity": "sha512-u6k1QHq4xmuBakQ2m4dkCJ/hhrol2vmOFAdrKCzR+qriiaJBYrgD5Dm3DhiUVrpowSZdkeBAR4Ihn4Ir7TRLPw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.3.tgz",
-      "integrity": "sha512-xQQqmSRNFl0yCEzn6Cu8nfTAeoRo9ZxFzzRp1CNMTxfOxVhkU7ZekYzuqoEs/sTD8yPF5uIfkE/iM69UVS/6xQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.3.tgz",
-      "integrity": "sha512-HEIm/gSdTxGkmO8kvIlzlk219B/MOt/KVzsyGg168shm4I1Q/JA6lQz43o1cfu6hHHzvKxpehFogzO0sameCgA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.3.tgz",
-      "integrity": "sha512-zOopC75LakngPJTqk4CA9DkMUiNVEZAkL/FfsgtUfl/u5RxcVta7Uj/2efxWwuFJbLbCLb16nbfbhaiEy+Ti/Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-ref": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.3.tgz",
-      "integrity": "sha512-sOI1Z0v2NE5qzFcXndY71d+P6zztgBAlSTmZzKr7oe9CzlE/5diVKP1zKBcS8ZKeFPCC2MmommSoYfDbUnWzNQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.3.tgz",
-      "integrity": "sha512-/EKt7w1vHGoa4WbqsnjHIzmQOG5x9Sy+wbwo6gU4s5SdxGFTAeCcIeybMqb/+blr3P0BYOS6MC+UU1osViva2g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.3.tgz",
-      "integrity": "sha512-A3+MFnt84KzfTw5fXcjmcOsz1VVEwayy6bEw5XiPqEK6JvQw1dJHsKZd7Mfu5TQcphAEWI2h2zRB9NtgIO4Ciw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.3.tgz",
-      "integrity": "sha512-FlznsRXFdNGW/2L7zxWWdtBJ1jgoqnVbEVp4gwiapIYwHS7sd7IwEcVUhrCKRUBlnmAz1oZWbyRqkoQVffEOgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.3.tgz",
-      "integrity": "sha512-5v/dvKbvfg3RjbJNtkGkgNrpicqbkwlehJQGxhbixpSqUiROKGUWZZ6gzlrw9mFz9by2OXuBQTCJQgXQt9mmZQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.3.tgz",
-      "integrity": "sha512-V1qiUrZpl0o7XiluWoegZbXgOuuxGsilDjjoC6p8+f0A7qIC37UIRYq+4gJVg4OxabwAisH7LEm5IJFlIgZJSw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-ref-node": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-responsive-container": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.3.tgz",
-      "integrity": "sha512-L4BzPIjSkaAEDUppT/66hxsqfDfh1iP42pv68OeqPD9ygw6GU67bv2aOV4N5BFEi1VJHq6Oi3So4RVaeFQtRYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-button-group": "1.17.3",
-        "@umbraco-ui/uui-popover-container": "1.17.3",
-        "@umbraco-ui/uui-symbol-more": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.3.tgz",
-      "integrity": "sha512-k+io6hBzcvUfv+5Zucv68e1oF6UJ2DOgByhM9uIuiHWSZdvodG/3neFEIDPQJ+EaNPcJ6K+QzJs0T16QEZW0cA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.3.tgz",
-      "integrity": "sha512-y0lapeDWK84R4u2xeNrgex0d5BVHwcljlqejoT8A/tWwTSGJ15viv3mgrJV8j9gkTgYF5Fz22ASZpO8vqC0wEw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.3.tgz",
-      "integrity": "sha512-Aw8dO6EUvpu26yJ24fyazDXhsd94dWMttIiy/Fq1uP49ZsNsphiEWwOamc5fZIMcl7svNy6WBCbaTLEWvWNeUw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.3.tgz",
-      "integrity": "sha512-mT0sXdERzZBU5ePEiprdpTRcSEASeUErlB/XCyNPiW1FMW62/JNIXXmQ6lPymouzZqjB7z3+/wJR/jKlcpgQdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.3.tgz",
-      "integrity": "sha512-+QMl/OJUNwa2X1NyvAY3Ogko/ijwLhe/SRTQjkF5tqyVq+hJEPDER+Ij1n38FmJuYmmCEkP29KTDECTWcEqnfA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.3.tgz",
-      "integrity": "sha512-g5SA+JqlTO6vNmH3vnSCNpj2tucOqGp6glaWWAWgq7ZttjOxMjwvRGBMc62/A31tlbUPI27vt7RPngWQeR+vmg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.3.tgz",
-      "integrity": "sha512-x9ggQviV0sKzELCdDNlQvlc+0xo9bEokm4OG6+EwKRo6MzlOaGA/xmtMFwEX/NBgyydK3+hzw1P6mLK0hO8Lyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.3.tgz",
-      "integrity": "sha512-v3LfxsNNbLXqXaxn/JqWys8rkuIo1agNVrgmw/zWG+XzIz0LhhQlVIv70lSW+kdVtNLzdy1LF64Eac3iSxgqVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.3.tgz",
-      "integrity": "sha512-WZvGQXJw2tLx9asCLeMQS+leNy80AkMnyIPHGTxFXUa4o6csnGuwsBElfhXyaEUdMBsciwmNCuJsD9EY77dOfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.3.tgz",
-      "integrity": "sha512-BQ58zFIvGTRpLHfTCtI+rENdFViJWoBFgdMF5Y5wA6Li7/VPfzAAezcFvMhsoHFMojLvfoBqFkCkqjvaJPohTg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.3.tgz",
-      "integrity": "sha512-PulzS0gWeBxJobOAz6u7TFqX4TrzvjuVb1gqg0D4BednL1U7n7y1/dEmJlqVxDe9N6vcyls0yC4LuhiEIoxBwQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.3.tgz",
-      "integrity": "sha512-HPpt5/nJNwtD/lvsvW4+piEPRoXYeHyAiELeoi2c/oy+9JUcBU1cGTEEBlAvqBVjuAPGE148EIF/aVSNrJ+GTg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.3.tgz",
-      "integrity": "sha512-+zytU/gm1TGfSSigeaZGF/zNzSue2UU9X3Mml7ThKBxJM+Fmhn+00I/d62yWhbOiN+o5n8HNKEKeUO62N0uw3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-popover-container": "1.17.3",
-        "@umbraco-ui/uui-symbol-more": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.3.tgz",
-      "integrity": "sha512-B5noxWEAac2P7AJSg8iFNvZC+VxyMs2hb4sgEfagR2IfinPOTj7rDrKBU9ZjYfcUgiZFq4TUwvRxqPK+qce4SA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.3.tgz",
-      "integrity": "sha512-GrAJSwgsoZ8roWdHlL8WNoqmGjoznc3VnkBP6RYivrURpnCbvPVtl8iteWKfRxZfcBOIvI4johgiE4aae+ojTg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.3.tgz",
-      "integrity": "sha512-unykwkfV+ma0q9NTXdicICn61ilrEJlypdSdOzLCb5TiuR8jsPeeSsaMkVUEKs+JnJw5seh2kA95fUqKMCPeag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-button": "1.17.3",
-        "@umbraco-ui/uui-css": "1.17.3",
-        "@umbraco-ui/uui-icon": "1.17.3",
-        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.3.tgz",
-      "integrity": "sha512-pA8prAosV3Ga4UxQHeJ+a2sgXy4REb3PpZ2SKD7CnD0qNXsPfBm4sK5ewCHK2bbNnAgrMIHKNW97yOUMA9cicA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-toast-notification": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.3.tgz",
-      "integrity": "sha512-LZ2GMmjeV+dGNr8ZqQJqZOjFB3JuFdaazVkwLuqkVXpCg42j6QJKfzXsSLdY/tX4NJK3dAT06Xwxb+bMezrgEw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-css": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.3.tgz",
-      "integrity": "sha512-GsSDkhOm4KR1kd9KkxTkdp4flN6Sv9Nr6rHHgk0cl6ojsfiAQa6hTXYma2ZRs90DpZpD10Ll6P3ka6ZudSq+gw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3",
-        "@umbraco-ui/uui-boolean-input": "1.17.3"
-      }
-    },
-    "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.3.tgz",
-      "integrity": "sha512-DZTXqd0j7WuIWhNoFVn0B6rU+sbRHEhTqll5wU1lQTwz6XnGiXkmNC1YaIUy8GW9b3e22pTVzEjZ+kennOnPcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@umbraco-ui/uui-base": "1.17.3"
+        "culori": "^4.0.2",
+        "lit": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=24.13",
+        "npm": ">=11"
       }
     },
     "node_modules/abort-controller": {
@@ -2800,14 +1725,6 @@
         "color-support": "bin.js"
       }
     },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2841,6 +1758,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/culori": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
+      "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -2906,9 +1834,9 @@
       "peer": true
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -3246,9 +2174,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3933,9 +2861,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/UmbHost.Tables.Client/package.json
+++ b/UmbHost.Tables.Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umbhost-tables-client",
-  "version": "17.3.0",
+  "version": "18.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@umbraco-cms/backoffice": "^17.3.5",
+    "@umbraco-cms/backoffice": "^18.0.2",
     "lit": "^3.2.0",
     "typescript": "~5.6.3",
     "vite": "^6.4.2"

--- a/UmbHost.Tables.Client/public/umbraco-package.json
+++ b/UmbHost.Tables.Client/public/umbraco-package.json
@@ -2,7 +2,7 @@
   "$schema": "../../umbraco-package-schema.json",
   "id": "UmbHost.Tables",
   "name": "UmbHost Tables",
-  "version": "17.0.3",
+  "version": "18.0.0",
   "extensions": [
     {
       "type": "propertyEditorUi",

--- a/UmbHost.Tables/UmbHost.Tables.csproj
+++ b/UmbHost.Tables/UmbHost.Tables.csproj
@@ -9,14 +9,14 @@
     <!-- Package Info -->
     <PackageId>UmbHost.Tables</PackageId>
     <!-- Fallback for untagged builds; the Release workflow overrides this from the git tag. -->
-    <Version>17.3.0</Version>
+    <Version>18.0.0</Version>
     <Authors>UmbHost</Authors>
     <Company>UmbHost</Company>
-    <Description>A table property editor for Umbraco 17 that allows content editors to create and manage tabular data with support for header rows/columns and rich text editing.</Description>
+    <Description>A table property editor for Umbraco 18 that allows content editors to create and manage tabular data with support for header rows/columns and rich text editing.</Description>
     <PackageProjectUrl>https://github.com/UmbHost/UmbHost.Tables</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UmbHost/UmbHost.Tables</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>umbraco;umbraco-cms;umbraco-package;table;tables;table-editor;property-editor;umbraco-v17;umbraco-marketplace</PackageTags>
+    <PackageTags>umbraco;umbraco-cms;umbraco-package;table;tables;table-editor;property-editor;umbraco-v18;umbraco-marketplace</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>table.png</PackageIcon>
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Core" Version="17.5.3" />
+    <PackageReference Include="Umbraco.Cms.Core" Version="18.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UmbHost.Tables/wwwroot/umbraco-package.json
+++ b/UmbHost.Tables/wwwroot/umbraco-package.json
@@ -2,7 +2,7 @@
   "$schema": "../../umbraco-package-schema.json",
   "id": "UmbHost.Tables",
   "name": "UmbHost Tables",
-  "version": "17.0.3",
+  "version": "18.0.0",
   "extensions": [
     {
       "type": "propertyEditorUi",


### PR DESCRIPTION
Umbraco 18 needs **no code changes**. Verified before writing any:

| Check | Result |
|---|---|
| `dotnet build` against `Umbraco.Cms.Core` 18.0.2 | 0 errors, **0 warnings** |
| 41 tests against 18.0.2 | all pass |
| `tsc --noEmit` against `@umbraco-cms/backoffice` 18.0.2 | clean |
| v18 tiptap API (`UmbTiptapRteContext`, `getEditor()`, `umb-input-tiptap`) | present |

Zero warnings is the meaningful one — `HtmlLocalLinkParser`'s legacy members are marked "scheduled for removal in Umbraco 18", but this package only calls the surviving overloads.

The compiled bundle is **byte-identical** after rebuilding against v18 types. `@umbraco*` imports are externalised and resolved against the host backoffice at runtime, so one bundle serves both majors; only `umbraco-package.json` changed.

## Branch layout

`main` is now the 18.x line and `v17/main` the 17.x maintenance line, keeping the convention that the package major tracks the Umbraco major — the rule your four published versions already established.

| Umbraco | UmbHost.Tables | Branch |
|---------|----------------|--------|
| 18.x    | 18.x           | `main` |
| 17.x    | 17.x           | `v17/main` |

`v17/main` was cut from `28c5aed`, so it carries 17.3.0 against Umbraco 17.5.3 and is ready to tag `v17.3.0` independently.

## Changes

- `Umbraco.Cms.Core` 17.5.3 → 18.0.2, package version → 18.0.0
- Description and `umbraco-v17` tag updated to 18
- `@umbraco-cms/backoffice` devDependency → `^18.0.2` (types only)
- **`umbraco-package.json` version fixed** — it had drifted to `17.0.3`, several releases behind, in both `Client/public/` (the source) and `wwwroot/` (generated)
- CI now runs on `main` and `v17/main`
- README gains a version compatibility table

Verified: `dotnet pack` produces `UmbHost.Tables.18.0.0.nupkg`.

## Follow-up

`v17/main` still has CI triggers for `main` only, since it was cut before this change. A small PR against that branch will fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
