### PR TITLE
Run CI on the v17 maintenance branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - main       # Umbraco 18 line
+      - v17/main   # Umbraco 17 maintenance line
   pull_request:
     branches:
       - main
+      - v17/main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # UmbHost.Tables
 
-A table property editor for Umbraco 17+ that allows content editors to create and manage tabular data with support for header rows, header columns, and inline editing.
+A table property editor for Umbraco 17 and 18 that allows content editors to create and manage tabular data with support for header rows, header columns, and inline editing.
+
+## Version compatibility
+
+The package major tracks the Umbraco major, so pick the line that matches your site:
+
+| Umbraco | UmbHost.Tables | Branch |
+|---------|----------------|--------|
+| 18.x    | 18.x           | `main` |
+| 17.x    | 17.x           | `v17/main` |
+
+This branch is the 17.x maintenance line.
 
 ## Features
 


### PR DESCRIPTION
`v17/main` was cut from `main` before CI learned about it, so its workflow only triggers on `main` — nothing would run on this branch or its PRs.

Adds `v17/main` to the CI triggers, and documents which package line matches which Umbraco major so anyone landing here knows 18.x exists.

Verified on this branch: build clean with 0 warnings, 41 tests pass, still on `Umbraco.Cms.Core` 17.5.3 at version 17.3.0.

Companion to #12, which moves `main` to the Umbraco 18 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
